### PR TITLE
Admin merchant enable disable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.18.0)
+    loofah (2.19.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)

--- a/app/controllers/admin_merchants_controller.rb
+++ b/app/controllers/admin_merchants_controller.rb
@@ -13,13 +13,18 @@ class AdminMerchantsController < ApplicationController
 
   def update
     merchant = Merchant.find(params[:id])
-    merchant.update(merchant_params)
-    redirect_to "/admin/merchants/#{merchant.id}", notice: "Update to #{merchant.name} was successful!"
+    if params[:status]
+      merchant.update(merchant_params)
+      redirect_to "/admin/merchants"
+    else
+      merchant.update(merchant_params)
+      redirect_to "/admin/merchants/#{merchant.id}", notice: "Update to #{merchant.name} was successful!"
+    end
   end
 
 private
   def merchant_params
-    params.permit(:name)
+    params.permit(:name, :status)
   end
 
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,5 +1,6 @@
 class Merchant < ApplicationRecord
   validates_presence_of :name
+  enum status: { Enabled: 0, Disabled: 1}
 
   has_many :items
   has_many :invoice_items, through: :items

--- a/app/views/admin_merchants/index.html.erb
+++ b/app/views/admin_merchants/index.html.erb
@@ -1,5 +1,13 @@
 <h1>Admin Merchants Index</h1>
 <% @merchants.each do |merchant| %>
-  <section id="merchant-<%= merchant.id %>">
-    <p><strong><%= link_to "#{merchant.name}", "/admin/merchants/#{merchant.id}" %></strong></p>
-<% end %></section>
+
+    <section id="merchant-<%= merchant.id %>">
+      <p><% if merchant.status == "Enabled" %>
+        <h3><strong><%= link_to "#{merchant.name}", "/admin/merchants/#{merchant.id}" %></h5></strong>
+        <%= button_to "Disable", "/admin/merchants/#{merchant.id}", method: :patch, params: {status: "Disabled"} %></p>
+
+      <p><% elsif merchant.status == "Disabled"%>
+        <h3><strong><%= link_to "#{merchant.name}", "/admin/merchants/#{merchant.id}" %></h5></strong>
+        <%= button_to "Enable", "/admin/merchants/#{merchant.id}", method: :patch, params: {status: "Enabled"} %></p>
+      <% end %></section>
+<% end %>

--- a/app/views/admin_merchants/index.html.erb
+++ b/app/views/admin_merchants/index.html.erb
@@ -1,4 +1,5 @@
 <h1>Admin Merchants Index</h1>
 <% @merchants.each do |merchant| %>
-  <p><strong><%= link_to "#{merchant.name}", "/admin/merchants/#{merchant.id}" %></strong></p>
-<% end %>
+  <section id="merchant-<%= merchant.id %>">
+    <p><strong><%= link_to "#{merchant.name}", "/admin/merchants/#{merchant.id}" %></strong></p>
+<% end %></section>

--- a/db/migrate/20220916163432_add_status_to_merchants.rb
+++ b/db/migrate/20220916163432_add_status_to_merchants.rb
@@ -1,0 +1,5 @@
+class AddStatusToMerchants < ActiveRecord::Migration[5.2]
+  def change
+    add_column :merchants, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_13_230254) do
+ActiveRecord::Schema.define(version: 2022_09_16_163432) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 2022_09_13_230254) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0
   end
 
   create_table "transactions", force: :cascade do |t|

--- a/spec/features/admin_merchants/index_spec.rb
+++ b/spec/features/admin_merchants/index_spec.rb
@@ -1,13 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin Merchants Index' do
+  before :each do
+    @merchant_1 = Merchant.create!(name: "Bread Pitt")
+    @merchant_2 = Merchant.create!(name: "Carrie Breadshaw")
+    @merchant_3 = Merchant.create!(name: "Sheena Yeaston")
+    @merchant_4 = Merchant.create!(name: "Taylor Sift")
+  end
+
   describe 'US6' do
     it 'shows the name of all the merchants in the system' do
-      merchant_1 = Merchant.create!(name: "Bread Pitt")
-      merchant_2 = Merchant.create!(name: "Carrie Breadshaw")
-      merchant_3 = Merchant.create!(name: "Sheena Yeaston")
-      merchant_4 = Merchant.create!(name: "Taylor Sift")
-
       visit "/admin/merchants"
 
       expect(page).to have_content("Bread Pitt")
@@ -20,16 +22,33 @@ RSpec.describe 'Admin Merchants Index' do
 
   describe 'US7' do
     it 'has a link on each merchants name taking you to their individual show page with their name' do
-      merchant_1 = Merchant.create!(name: "Bread Pitt")
-      merchant_2 = Merchant.create!(name: "Carrie Breadshaw")
-
       visit "/admin/merchants"
-      click_link "#{merchant_1.name}"
+      click_link "#{@merchant_1.name}"
 
-      expect(current_path).to eq("/admin/merchants/#{merchant_1.id}")
+      expect(current_path).to eq("/admin/merchants/#{@merchant_1.id}")
       expect(page).to have_content("Bread Pitt")
       expect(page).to_not have_content("Carrie Breadshaw")
     end
+  end
+
+  describe 'US9' do
+    it 'can enable/disable merchants' do
+       # As an admin,
+      # When I visit the admin merchants index
+      visit "/admin/merchants"
+      # Then next to each merchant name I see a button to disable or enable that merchant.
+      within("#merchant-#{@merchant_1.id}") do
+        expect(page).to have_button("Enable")
+        expect(page).to have_button("Disable")
+        # When I click this button
+        click_button("Enable")
+        # Then I am redirected back to the admin merchants index
+        expect(current_path).to eq("/admin/merchants")
+        # And I see that the merchant's status has changed
+        expect(page).to have_content("Status - Enabled")
+      end
+    end
+
   end
 
 end

--- a/spec/features/admin_merchants/index_spec.rb
+++ b/spec/features/admin_merchants/index_spec.rb
@@ -32,22 +32,33 @@ RSpec.describe 'Admin Merchants Index' do
   end
 
   describe 'US9' do
-    it 'can enable/disable merchants' do
+    it 'can disable merchants' do
        # As an admin,
       # When I visit the admin merchants index
       visit "/admin/merchants"
       # Then next to each merchant name I see a button to disable or enable that merchant.
       within("#merchant-#{@merchant_1.id}") do
-        expect(page).to have_button("Enable")
         expect(page).to have_button("Disable")
-        # When I click this button
-        click_button("Enable")
+        # click_button("Disable")
+        click_button("Disable")
+
         # Then I am redirected back to the admin merchants index
         expect(current_path).to eq("/admin/merchants")
         # And I see that the merchant's status has changed
-        expect(page).to have_content("Status - Enabled")
+        expect(page).to have_button("Enable")
       end
     end
+
+    it 'can enable merchants' do
+     visit "/admin/merchants"
+     within("#merchant-#{@merchant_2.id}") do
+     click_button("Disable")
+     expect(page).to have_button("Enable")
+     click_button("Enable")
+     expect(current_path).to eq("/admin/merchants")
+     expect(page).to have_button("Disable")
+     end
+   end
 
   end
 


### PR DESCRIPTION
Added enum related to merchants for 'enable' and 'disable' status

added buttons to merchants to enable and disable status

status will change once button is pushed and bring you back to the same page showing the new status and opposite button available to change it again